### PR TITLE
feat: Add support for path-style S3 URLs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,7 @@ func NewS3Client() *S3Client {
 				"",
 			),
 		),
+		UsePathStyle: os.Getenv("USE_PATH_STYLE") == "true",
 	}
 	client := s3.New(options)
 	presignClient := s3.NewPresignClient(client)


### PR DESCRIPTION
Adds a new configuration option `UsePathStyle` to the S3 client
that allows using path-style URLs instead of the default
virtual-hosted-style URLs. This is useful for S3-compatible
storage services that do not support virtual-hosted-style URLs.

The new option is controlled by the `USE_PATH_STYLE` environment
variable, which can be set to `"true"` to enable path-style URLs.