### PR TITLE
feat: Improve S3 response handling and add shared HTTP client

### DIFF
--- a/api/s3.go
+++ b/api/s3.go
@@ -22,25 +22,34 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer output.Body.Close()
-	w.WriteHeader(output.StatusCode)
+
+	// Set all headers from S3 response first
 	for key, values := range output.Header {
 		for _, value := range values {
-			if strings.Contains(key, "Wasabi") {
-				continue
-			}
-			if strings.Contains(value, "Wasabi") {
+			// Skip Wasabi-specific headers if they are not desired in the final response
+			if strings.Contains(key, "Wasabi") || strings.Contains(value, "Wasabi") {
 				continue
 			}
 			w.Header().Add(key, value)
 		}
 	}
+
+	// Determine the final status code
+	statusCode := output.StatusCode
 	if output.Header.Get("Content-Range") != "" {
+		// For partial content requests, set Content-Length and Content-Type, and use 206 Partial Content status
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", output.ContentLength))
+		// The original code explicitly set application/octet-stream for partial content.
+		// If the original S3 Content-Type should be preserved, use: w.Header().Set("Content-Type", output.Header.Get("Content-Type"))
 		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusPartialContent)
+		statusCode = http.StatusPartialContent
 	}
 
+	// Write the header with the determined status code
+	w.WriteHeader(statusCode)
+
+	// Copy the S3 object body to the HTTP response writer
 	if _, err := io.Copy(w, output.Body); err != nil {
-		log.Println(err)
+		log.Println("Error copying S3 object body to response writer:", err)
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,8 @@ import (
 )
 
 type S3Client struct {
-	pc *s3.PresignClient
+	pc         *s3.PresignClient
+	httpClient *http.Client // Add a shared HTTP client
 }
 
 func NewS3Client() *S3Client {
@@ -31,7 +32,8 @@ func NewS3Client() *S3Client {
 	client := s3.New(options)
 	presignClient := s3.NewPresignClient(client)
 	return &S3Client{
-		pc: presignClient,
+		pc:         presignClient,
+		httpClient: &http.Client{}, // Initialize the shared HTTP client
 	}
 }
 
@@ -70,6 +72,5 @@ func (c *S3Client) GetObject(
 	}
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Pragma", "no-cache")
-	httpClient := http.Client{}
-	return httpClient.Do(req)
+	return c.httpClient.Do(req) // Use the shared HTTP client
 }


### PR DESCRIPTION
This change improves the handling of S3 responses in the API and client code. The
key changes are:

1. Set all headers from the S3 response, except for Wasabi-specific headers.
2. Determine the appropriate status code based on the S3 response, including
   handling partial content requests.
3. Add a shared HTTP client to the S3 client, which is used for all requests.
   This helps to reuse connections and improve performance.