### PR TITLE
feat(api): Implement S3 object retrieval handler

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -1,64 +1,23 @@
 package main
 
 import (
-	"fmt"
-	"io"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/media-cdn/s3/client" // Re-import the client package
+	handler "github.com/media-cdn/s3/api"
+	// Re-import the client package
 )
 
 func main() {
-	// register the handler
-	s3Client := client.NewS3Client()
 	// start the server
 	port := ":8080"
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Use(middleware.StripSlashes)
 	r.Use(middleware.CleanPath)
-	r.Get("/{bucket}/*", func(w http.ResponseWriter, r *http.Request) {
-		bucketName := chi.URLParam(r, "bucket")
-		path := chi.URLParam(r, "*")
-		output, err := s3Client.GetObject(r.Context(), bucketName, path, r.Header)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer output.Body.Close()
-
-		// Set all headers from S3 response first
-		for key, values := range output.Header {
-			for _, value := range values {
-				// Skip Wasabi-specific headers if they are not desired in the final response
-				if strings.Contains(key, "Wasabi") || strings.Contains(value, "Wasabi") {
-					continue
-				}
-				w.Header().Add(key, value)
-			}
-		}
-
-		// Determine the final status code
-		statusCode := output.StatusCode
-		if output.Header.Get("Content-Range") != "" {
-			// For partial content requests, set Content-Length and Content-Type, and use 206 Partial Content status
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", output.ContentLength))
-			w.Header().Set("Content-Type", "application/octet-stream")
-			statusCode = http.StatusPartialContent
-		}
-
-		// Write the header with the determined status code
-		w.WriteHeader(statusCode)
-
-		// Copy the S3 object body to the HTTP response writer
-		if _, err := io.Copy(w, output.Body); err != nil {
-			log.Println("Error copying S3 object body to response writer:", err)
-		}
-	})
+	r.Get("/{bucket}/*", handler.Handler)
 	if err := http.ListenAndServe(port, r); err != nil {
 		log.Fatal("ListenAndServe:", err)
 	}


### PR DESCRIPTION
Refactor the main.go file to use a dedicated API handler for
retrieving S3 objects. This change separates the main server
setup logic from the S3 object retrieval logic, making the
code more modular and easier to maintain.

The new API handler encapsulates the logic for setting the
appropriate response headers and status codes based on the
S3 object metadata.