### PR TITLE
feat(s3): Refactor S3Client interface to use direct S3 API

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1,0 +1,105 @@
+# Refactor S3Client Interface
+
+## Tổng quan
+Đã thực hiện refactor toàn bộ interface của S3Client để thay thế cơ chế presigned URL bằng việc tải file trực tiếp từ S3.
+
+## Thay đổi chính
+
+### 1. Interface mới
+```go
+type Downloader interface {
+    GetObject(ctx context.Context, bucket, key string, opts ...DownloadOption) (*S3Object, error)
+    HeadObject(ctx context.Context, bucket, key string) (*S3Object, error)
+    Close() error
+}
+```
+
+### 2. Struct S3Object
+```go
+type S3Object struct {
+    Body          io.ReadCloser     // Stream dữ liệu
+    ContentType   string            // Loại nội dung
+    ContentLength int64             // Kích thước nội dung
+    ContentRange  string            // Range cho partial content
+    ETag          string            // Entity tag
+    Metadata      map[string]string // Metadata bổ sung
+    StatusCode    int               // HTTP status code
+}
+```
+
+### 3. Options Pattern
+```go
+type DownloadOption func(*s3.GetObjectInput)
+
+func WithRange(start, end int64) DownloadOption
+func WithRangeHeader(rangeHeader string) DownloadOption
+```
+
+## Lợi ích
+
+### 1. Hiệu suất
+- **Trước**: Tạo presigned URL → HTTP request riêng → Thêm latency
+- **Sau**: Gọi trực tiếp S3 API → Giảm latency
+
+### 2. Bảo mật  
+- Không cần expose presigned URL
+- Kiểm soát truy cập tốt hơn
+
+### 3. Linh hoạt
+- Options pattern cho các tuỳ chọn download
+- Dễ mở rộng với chức năng mới
+
+### 4. Maintainability
+- Interface rõ ràng, tách biệt concerns
+- Dễ test và mock
+
+## Migration Guide
+
+### API Handler
+**Trước**:
+```go
+output, err := s3Client.GetObject(r.Context(), bucketName, path, r.Header)
+// output là *http.Response
+```
+
+**Sau**:
+```go
+output, err := s3Client.GetObject(r.Context(), bucketName, path, 
+    client.WithRangeHeader(r.Header.Get("Range")))
+// output là *client.S3Object
+```
+
+### Header Handling
+**Trước**:
+```go
+for key, values := range output.Header {
+    // Copy headers từ http.Response
+}
+```
+
+**Sau**:
+```go
+if output.ContentType != "" {
+    w.Header().Set("Content-Type", output.ContentType)
+}
+if output.ContentLength > 0 {
+    w.Header().Set("Content-Length", fmt.Sprintf("%d", output.ContentLength))
+}
+// Xử lý từng field riêng biệt
+```
+
+## Breaking Changes
+- Thay đổi signature hàm `GetObject`
+- Thay đổi kiểu trả về từ `*http.Response` sang `*S3Object`
+- Headers không còn được copy tự động
+
+## Tests
+Đã thêm unit tests để verify:
+- Interface implementation
+- Options pattern functionality
+- Range header processing
+
+## Files đã thay đổi
+- `client/client.go`: Refactor toàn bộ interface
+- `api/s3.go`: Cập nhật để sử dụng interface mới
+- `client/client_test.go`: Thêm unit tests

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestS3Client_Interface(t *testing.T) {
+	// Test interface implementation
+	var _ Downloader = (*S3Client)(nil)
+}
+
+func TestWithRangeHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		rangeHeader string
+		expectRange bool
+	}{
+		{
+			name:        "empty range header",
+			rangeHeader: "",
+			expectRange: false,
+		},
+		{
+			name:        "valid range header",
+			rangeHeader: "bytes=0-1023",
+			expectRange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &s3.GetObjectInput{}
+			opt := WithRangeHeader(tt.rangeHeader)
+			opt(input)
+
+			if tt.expectRange && input.Range == nil {
+				t.Error("expected Range to be set")
+			}
+			if !tt.expectRange && input.Range != nil {
+				t.Error("expected Range to be nil")
+			}
+		})
+	}
+}
+
+func TestWithRange(t *testing.T) {
+	input := &s3.GetObjectInput{}
+	opt := WithRange(0, 1023)
+	opt(input)
+
+	if input.Range == nil {
+		t.Fatal("expected Range to be set")
+	}
+
+	expected := "bytes=0-1023"
+	if *input.Range != expected {
+		t.Errorf("expected Range=%q, got %q", expected, *input.Range)
+	}
+}


### PR DESCRIPTION
The changes in this commit refactor the entire S3Client interface to replace the presigned URL mechanism with direct file uploads from S3.

The key changes include:

1. A new `Downloader` interface with methods to get and head S3 objects.
2. A new `S3Object` struct to represent the downloaded object data.
3. An "Options Pattern" to allow customizing the download behavior.

The main benefits of these changes are:

- Improved performance by eliminating the extra HTTP request for presigned URLs.
- Better security by not exposing presigned URLs.
- Increased flexibility with the options pattern.
- Improved maintainability with a clear interface and separation of concerns.

This change also introduces some breaking changes, such as changes to the `GetObject` function signature and the response type. A migration guide and unit tests are provided to help with the transition.

The affected files are:
- `client/client.go`: Refactor the entire interface.
- `api/s3.go`: Update to use the new interface.
- `client/client_test.go`: Add unit tests.