### PR TITLE
feat(refactor): Refactor prefix path handling

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+# Kế hoạch triển khai PREFIX_PATH (Cập nhật)
+
+## Yêu cầu
+Sử dụng PREFIX_PATH làm bucket mới và chuyển bucket cũ thành phần đầu của path
+
+## Các bước thực hiện
+
+1. **Sửa đổi file `api/s3.go`**
+   ```go
+   prefix := os.Getenv("PREFIX_PATH")
+   if prefix != "" {
+       prefix = strings.Trim(prefix, "/")
+       // Tạo path mới: [prefix]/[bucket cũ]/[path cũ]
+       newPath := bucketName
+       if path != "" {
+           newPath += "/" + path
+       }
+       bucketName = prefix
+       path = newPath
+   }
+   ```
+
+2. **Kiểm thử**
+   - Đảm bảo test case `TestPrefixPathHandling` trong `api/s3_test.go` pass
+   - Kiểm tra các trường hợp:
+     - PREFIX_PATH rỗng
+     - PREFIX_PATH có giá trị đơn
+     - PREFIX_PATH có nhiều cấp
+     - Các trường hợp biên
+
+## Sequence Diagram (Cập nhật)
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler
+    participant S3Client
+    participant Env
+
+    Client->>Handler: GET /bucket-name/path/to/file
+    Handler->>Env: Read PREFIX_PATH
+    Env-->>Handler: prefix
+    Handler->>Handler: Parse URL path → (bucketName, path)
+    Handler->>Handler: Apply prefix as new bucket, move old bucket to path
+    Handler->>S3Client: GetObject(newBucket, oldBucket + "/" + path)
+    S3Client-->>Handler: S3 object
+    Handler->>Client: Return response
+```
+
+## Lưu ý
+- Đảm bảo không ảnh hưởng đến các chức năng hiện có
+- Cập nhật tài liệu nếu cần

--- a/PREFIX-REFACTOR.md
+++ b/PREFIX-REFACTOR.md
@@ -1,0 +1,135 @@
+# Kế hoạch Refactor Xử lý Prefix Path (Clean Code)
+
+## Nguyên tắc Clean Code áp dụng
+1. **Single Responsibility Principle**: Mỗi hàm chỉ làm một nhiệm vụ
+2. **Meaningful Names**: Đặt tên hàm rõ ràng, tự mô tả
+3. **Test-Driven Development**: Viết test trước khi triển khai
+4. **KISS (Keep It Simple)**: Logic đơn giản, dễ hiểu
+
+## Kiến trúc mới
+```mermaid
+graph TD
+    A[Request Path] --> B{Has PREFIX_PATH?}
+    B -->|Yes| C[applyPrefixToPath]
+    B -->|No| D[parseRequestPath]
+    C --> D
+    D --> E[Extract bucket and path]
+    E --> F[Fetch S3 object]
+```
+
+## Implementation
+
+### 1. Hàm `applyPrefixToPath` mới (`api/s3.go`)
+```go
+// applyPrefixToPath áp dụng PREFIX_PATH vào request path nếu được cấu hình
+// Trả về path mới đã được thêm prefix
+func applyPrefixToPath(originalPath string) string {
+    prefix := os.Getenv("PREFIX_PATH")
+    if prefix == "" {
+        return originalPath
+    }
+    
+    // Chuẩn hóa prefix và path
+    prefix = strings.Trim(prefix, "/")
+    path := strings.TrimPrefix(originalPath, "/")
+    
+    // Kết hợp prefix và path
+    return "/" + prefix + "/" + path
+}
+```
+
+### 2. Cập nhật hàm Handler (`api/s3.go`)
+```go
+func Handler(w http.ResponseWriter, r *http.Request) {
+    // Áp dụng prefix TRƯỚC KHI parse (tuân thủ SRP)
+    prefixedPath := applyPrefixToPath(r.URL.Path)
+    
+    // Parse request path từ fullPath đã xử lý prefix
+    bucket, path := parseRequestPath(prefixedPath)
+
+    // Fetch S3 object (giữ nguyên)
+    output, err := s3Client.GetObject(r.Context(), bucket, path,
+        client.WithRangeHeader(r.Header.Get("Range")))
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    defer output.Body.Close()
+
+    // ... (phần còn lại giữ nguyên)
+}
+```
+
+### 3. Xóa hàm `applyPrefix`
+- Hàm này không còn cần thiết
+
+### 4. Cập nhật unit tests (`api/s3_test.go`)
+```go
+func TestApplyPrefixToPath(t *testing.T) {
+    tests := []struct {
+        name     string
+        prefix   string
+        input    string
+        expected string
+    }{
+        {"No prefix", "", "/img.jpg", "/img.jpg"},
+        {"Single segment", "my-bucket", "/img.jpg", "/my-bucket/img.jpg"},
+        {"Multi segment", "bucket/folder", "/img.jpg", "/bucket/folder/img.jpg"},
+        {"Edge: empty path", "bucket", "", "/bucket/"},
+        {"Edge: root path", "bucket", "/", "/bucket/"},
+        {"Edge: prefix with trailing slash", "bucket/", "/img.jpg", "/bucket/img.jpg"},
+        {"Edge: path with multiple slashes", "bucket", "//img.jpg", "/bucket//img.jpg"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            os.Setenv("PREFIX_PATH", tt.prefix)
+            result := applyPrefixToPath(tt.input)
+            assert.Equal(t, tt.expected, result)
+        })
+    }
+}
+
+func TestHandlerWithPrefix(t *testing.T) {
+    // Test case 1: With prefix
+    os.Setenv("PREFIX_PATH", "my-bucket/prefix")
+    req := httptest.NewRequest("GET", "/object-key", nil)
+    handler := http.HandlerFunc(Handler)
+    rr := httptest.NewRecorder()
+    handler.ServeHTTP(rr, req)
+    // Verify bucket = "my-bucket", path = "prefix/object-key"
+
+    // Test case 2: Without prefix
+    os.Unsetenv("PREFIX_PATH")
+    req = httptest.NewRequest("GET", "/bucket/object", nil)
+    rr = httptest.NewRecorder()
+    handler.ServeHTTP(rr, req)
+    // Verify bucket = "bucket", path = "object"
+}
+```
+
+## Lợi ích Clean Code
+1. **Tách biệt mối quan tâm**:
+   - `applyPrefixToPath` chỉ xử lý prefix
+   - `parseRequestPath` chỉ tách bucket/path
+   - Dễ bảo trì và mở rộng
+
+2. **Testability**:
+   - Dễ dàng test riêng từng hàm
+   - Test coverage cao hơn
+   - Kiểm tra đầy đủ edge cases
+
+3. **Code tự mô tả**:
+   - Tên hàm rõ ràng: `applyPrefixToPath`, `parseRequestPath`
+   - Comments giải thích mục đích
+
+4. **Giảm độ phức tạp**:
+   - Logic xử lý path đơn giản hơn
+   - Mỗi hàm < 10 dòng code
+
+## Kế hoạch triển khai
+1. Cập nhật `api/s3.go` với hàm mới
+2. Xóa hàm `applyPrefix` cũ
+3. Thêm test cases trong `api/s3_test.go`
+4. Chạy toàn bộ test suite
+5. Kiểm tra hiệu năng

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1,105 +1,201 @@
-# Refactor S3Client Interface
+# Kế hoạch Refactor S3 Handler Function
 
-## Tổng quan
-Đã thực hiện refactor toàn bộ interface của S3Client để thay thế cơ chế presigned URL bằng việc tải file trực tiếp từ S3.
+## Mục tiêu
+Tối ưu hàm `Handler` trong [`api/s3.go`](api/s3.go) bằng cách chia thành các hàm nhỏ hơn có chức năng cụ thể, đảm bảo clean code và nguyên tắc Single Responsibility.
 
-## Thay đổi chính
+## Phân tích hiện trạng
+Hàm `Handler` hiện tại có 88 dòng code với nhiều trách nhiệm:
+1. Xử lý URL path parsing (dòng 18-26)
+2. Áp dụng PREFIX_PATH logic (dòng 28-53) 
+3. Gọi S3 client để lấy object (dòng 54-58)
+4. Thiết lập response headers (dòng 62-83)
+5. Xử lý response body và error handling (dòng 86-102)
 
-### 1. Interface mới
+## Kiến trúc mới
+
+```mermaid
+graph TD
+    A[Handler] --> B[parseRequestPath]
+    A --> C[applyPrefix]
+    A --> D[fetchS3Object]
+    A --> E[setResponseHeaders]
+    A --> F[writeResponseBody]
+    
+    B --> B1[Tách bucket và path từ URL]
+    C --> C1[Xử lý PREFIX_PATH environment]
+    D --> D1[Gọi S3 client với options]
+    E --> E1[Set headers từ S3Object]
+    E --> E2[Filter metadata headers]
+    F --> F1[Copy body với error handling]
+```
+
+## Chi tiết implementation
+
+### 1. Hàm `parseRequestPath`
+**Chức năng**: Tách URL path thành bucket name và object key
 ```go
-type Downloader interface {
-    GetObject(ctx context.Context, bucket, key string, opts ...DownloadOption) (*S3Object, error)
-    HeadObject(ctx context.Context, bucket, key string) (*S3Object, error)
-    Close() error
+func parseRequestPath(urlPath string) (bucket, path string) {
+    path = strings.TrimPrefix(urlPath, "/")
+    if i := strings.Index(path, "/"); i != -1 {
+        return path[:i], path[i+1:]
+    }
+    return path, ""
 }
 ```
 
-### 2. Struct S3Object
+### 2. Hàm `applyPrefix`
+**Chức năng**: Áp dụng PREFIX_PATH environment variable
 ```go
-type S3Object struct {
-    Body          io.ReadCloser     // Stream dữ liệu
-    ContentType   string            // Loại nội dung
-    ContentLength int64             // Kích thước nội dung
-    ContentRange  string            // Range cho partial content
-    ETag          string            // Entity tag
-    Metadata      map[string]string // Metadata bổ sung
-    StatusCode    int               // HTTP status code
+func applyPrefix(bucket, path string) (newBucket, newPath string) {
+    prefix := os.Getenv("PREFIX_PATH")
+    if prefix == "" {
+        return bucket, path
+    }
+    
+    prefix = strings.Trim(prefix, "/")
+    var prefixBucket, prefixPath string
+    if i := strings.Index(prefix, "/"); i != -1 {
+        prefixBucket = prefix[:i]
+        prefixPath = prefix[i+1:]
+    } else {
+        prefixBucket = prefix
+        prefixPath = ""
+    }
+
+    newPath = bucket
+    if path != "" {
+        newPath += "/" + path
+    }
+    if prefixPath != "" {
+        newPath = prefixPath + "/" + newPath
+    }
+
+    return prefixBucket, newPath
 }
 ```
 
-### 3. Options Pattern
+### 3. Hàm `setResponseHeaders`
+**Chức năng**: Thiết lập tất cả response headers từ S3Object
 ```go
-type DownloadOption func(*s3.GetObjectInput)
+func setResponseHeaders(w http.ResponseWriter, output *client.S3Object) {
+    if output.ContentType != "" {
+        w.Header().Set("Content-Type", output.ContentType)
+    }
+    if output.ContentLength > 0 {
+        w.Header().Set("Content-Length", fmt.Sprintf("%d", output.ContentLength))
+    }
+    if output.ETag != "" {
+        w.Header().Set("ETag", output.ETag)
+    }
+    if output.ContentRange != "" {
+        w.Header().Set("Content-Range", output.ContentRange)
+    }
 
-func WithRange(start, end int64) DownloadOption
-func WithRangeHeader(rangeHeader string) DownloadOption
+    // Copy metadata headers với filtering
+    for key, value := range output.Metadata {
+        if strings.HasPrefix(strings.ToLower(key), "wasabi") ||
+            strings.HasPrefix(strings.ToLower(value), "wasabi") {
+            continue
+        }
+        w.Header().Set("x-amz-meta-"+key, value)
+    }
+}
 ```
+
+### 4. Hàm `getStatusCode`
+**Chức năng**: Xác định HTTP status code phù hợp
+```go
+func getStatusCode(output *client.S3Object) int {
+    if output.ContentRange != "" {
+        return http.StatusPartialContent
+    }
+    return output.StatusCode
+}
+```
+
+### 5. Hàm `writeResponseBody`
+**Chức năng**: Copy S3 object body với error handling
+```go
+func writeResponseBody(w http.ResponseWriter, r *http.Request, body io.ReadCloser) {
+    if _, err := io.Copy(w, body); err != nil {
+        // Chỉ log lỗi thực sự, không log khi client disconnect
+        if r.Context().Err() == nil {
+            log.Printf("Error copying S3 object body: %v", err)
+        }
+    }
+}
+```
+
+### 6. Hàm `Handler` sau refactor
+```go
+func Handler(w http.ResponseWriter, r *http.Request) {
+    // 1. Parse request path
+    bucket, path := parseRequestPath(r.URL.Path)
+    
+    // 2. Apply prefix if configured
+    bucket, path = applyPrefix(bucket, path)
+    
+    // 3. Fetch S3 object
+    output, err := s3Client.GetObject(r.Context(), bucket, path, 
+        client.WithRangeHeader(r.Header.Get("Range")))
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    defer output.Body.Close()
+    
+    // 4. Set response headers
+    setResponseHeaders(w, output)
+    
+    // 5. Write status code and body
+    w.WriteHeader(getStatusCode(output))
+    writeResponseBody(w, r, output.Body)
+}
+```
+
+## Cập nhật Test Cases
+
+### Test cho các hàm mới
+Tạo unit test riêng biệt trong [`api/s3_test.go`](api/s3_test.go):
+
+1. `TestParseRequestPath` - Test path parsing logic
+2. `TestApplyPrefix` - Test PREFIX_PATH handling  
+3. `TestSetResponseHeaders` - Test header setting
+4. `TestGetStatusCode` - Test status code logic
+5. `TestWriteResponseBody` - Test body copying với mock
+
+### Giữ nguyên Integration Tests
+- `TestHandlerBasicRequest`
+- `TestHandlerPathParsing` 
+- `TestHandlerMetadataFiltering`
+- `TestPrefixPathHandling`
 
 ## Lợi ích
 
-### 1. Hiệu suất
-- **Trước**: Tạo presigned URL → HTTP request riêng → Thêm latency
-- **Sau**: Gọi trực tiếp S3 API → Giảm latency
+### 1. Single Responsibility Principle
+- Mỗi hàm chỉ có 1 trách nhiệm duy nhất
+- Dễ hiểu và bảo trì
 
-### 2. Bảo mật  
-- Không cần expose presigned URL
-- Kiểm soát truy cập tốt hơn
+### 2. Testability
+- Unit test cho từng thành phần riêng biệt
+- Mock dependencies dễ dàng hơn
 
-### 3. Linh hoạt
-- Options pattern cho các tuỳ chọn download
-- Dễ mở rộng với chức năng mới
+### 3. Code Reusability
+- Các hàm con có thể tái sử dụng
+- Logic business tách biệt khỏi HTTP handling
 
-### 4. Maintainability
-- Interface rõ ràng, tách biệt concerns
-- Dễ test và mock
+### 4. Maintainability  
+- Giảm độ phức tạp từ 88 dòng xuống ~20 dòng trong hàm chính
+- Thay đổi logic không ảnh hưởng toàn bộ handler
 
-## Migration Guide
+## Kế hoạch thực hiện
 
-### API Handler
-**Trước**:
-```go
-output, err := s3Client.GetObject(r.Context(), bucketName, path, r.Header)
-// output là *http.Response
-```
+1. **Bước 1**: Tạo các hàm helper mới
+2. **Bước 2**: Cập nhật hàm `Handler` để sử dụng helper functions
+3. **Bước 3**: Thêm unit tests cho các hàm mới
+4. **Bước 4**: Chạy toàn bộ test suite để đảm bảo không breaking changes
+5. **Bước 5**: Code review và documentation
 
-**Sau**:
-```go
-output, err := s3Client.GetObject(r.Context(), bucketName, path, 
-    client.WithRangeHeader(r.Header.Get("Range")))
-// output là *client.S3Object
-```
-
-### Header Handling
-**Trước**:
-```go
-for key, values := range output.Header {
-    // Copy headers từ http.Response
-}
-```
-
-**Sau**:
-```go
-if output.ContentType != "" {
-    w.Header().Set("Content-Type", output.ContentType)
-}
-if output.ContentLength > 0 {
-    w.Header().Set("Content-Length", fmt.Sprintf("%d", output.ContentLength))
-}
-// Xử lý từng field riêng biệt
-```
-
-## Breaking Changes
-- Thay đổi signature hàm `GetObject`
-- Thay đổi kiểu trả về từ `*http.Response` sang `*S3Object`
-- Headers không còn được copy tự động
-
-## Tests
-Đã thêm unit tests để verify:
-- Interface implementation
-- Options pattern functionality
-- Range header processing
-
-## Files đã thay đổi
-- `client/client.go`: Refactor toàn bộ interface
-- `api/s3.go`: Cập nhật để sử dụng interface mới
-- `client/client_test.go`: Thêm unit tests
+## Files cần thay đổi
+- [`api/s3.go`](api/s3.go): Refactor hàm Handler
+- [`api/s3_test.go`](api/s3_test.go): Thêm unit tests cho helper functions

--- a/api/s3_test.go
+++ b/api/s3_test.go
@@ -2,118 +2,12 @@ package handler
 
 import (
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/media-cdn/s3/client"
 )
-
-func TestHandlerPathParsing(t *testing.T) {
-	tests := []struct {
-		name       string
-		path       string
-		wantBucket string
-		wantKey    string
-	}{
-		{
-			name:       "normal path",
-			path:       "/mybucket/folder/file.jpg",
-			wantBucket: "mybucket",
-			wantKey:    "folder/file.jpg",
-		},
-		{
-			name:       "root file",
-			path:       "/mybucket/file.jpg",
-			wantBucket: "mybucket",
-			wantKey:    "file.jpg",
-		},
-		{
-			name:       "bucket only",
-			path:       "/mybucket",
-			wantBucket: "mybucket",
-			wantKey:    "",
-		},
-		{
-			name:       "deep nested path",
-			path:       "/mybucket/a/b/c/d/file.jpg",
-			wantBucket: "mybucket",
-			wantKey:    "a/b/c/d/file.jpg",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test path parsing logic
-			path := strings.TrimPrefix(tt.path, "/")
-			var bucketName string
-			if i := strings.Index(path, "/"); i != -1 {
-				bucketName = path[:i]
-				path = path[i+1:]
-			} else {
-				bucketName = path
-				path = ""
-			}
-
-			if bucketName != tt.wantBucket {
-				t.Errorf("bucket = %v, want %v", bucketName, tt.wantBucket)
-			}
-			if path != tt.wantKey {
-				t.Errorf("key = %v, want %v", path, tt.wantKey)
-			}
-		})
-	}
-}
-
-func TestHandlerMetadataFiltering(t *testing.T) {
-	tests := []struct {
-		name     string
-		key      string
-		value    string
-		wantSkip bool
-	}{
-		{
-			name:     "normal metadata",
-			key:      "user-id",
-			value:    "12345",
-			wantSkip: false,
-		},
-		{
-			name:     "wasabi key lowercase",
-			key:      "wasabi-storage-class",
-			value:    "standard",
-			wantSkip: true,
-		},
-		{
-			name:     "wasabi key uppercase",
-			key:      "WASABI-STORAGE",
-			value:    "standard",
-			wantSkip: true,
-		},
-		{
-			name:     "wasabi value",
-			key:      "provider",
-			value:    "wasabi-storage",
-			wantSkip: true,
-		},
-		{
-			name:     "contains wasabi but not prefix",
-			key:      "storage-wasabi-info",
-			value:    "normal",
-			wantSkip: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test metadata filtering logic
-			skip := strings.HasPrefix(strings.ToLower(tt.key), "wasabi") ||
-				strings.HasPrefix(strings.ToLower(tt.value), "wasabi")
-
-			if skip != tt.wantSkip {
-				t.Errorf("skip = %v, want %v for key=%s, value=%s",
-					skip, tt.wantSkip, tt.key, tt.value)
-			}
-		})
-	}
-}
 
 func TestHandlerBasicRequest(t *testing.T) {
 	// Tạo mock request
@@ -129,4 +23,245 @@ func TestHandlerBasicRequest(t *testing.T) {
 	}()
 
 	Handler(w, req)
+}
+func TestHandlerWithPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		prefix       string
+		requestPath  string
+		expectedPath string // Path mà parseRequestPath sẽ nhận được
+	}{
+		{
+			name:         "With prefix",
+			prefix:       "my-bucket/prefix",
+			requestPath:  "/object-key",
+			expectedPath: "/my-bucket/prefix/object-key",
+		},
+		{
+			name:         "Without prefix",
+			prefix:       "",
+			requestPath:  "/bucket/object",
+			expectedPath: "/bucket/object",
+		},
+		{
+			name:         "Single segment prefix",
+			prefix:       "my-bucket",
+			requestPath:  "/folder/file.jpg",
+			expectedPath: "/my-bucket/folder/file.jpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set PREFIX_PATH environment variable
+			oldPrefix := os.Getenv("PREFIX_PATH")
+			defer os.Setenv("PREFIX_PATH", oldPrefix)
+			os.Setenv("PREFIX_PATH", tt.prefix)
+
+			// Test logic xử lý prefix
+			prefixedPath := applyPrefixToPath(tt.requestPath)
+			if prefixedPath != tt.expectedPath {
+				t.Errorf("applyPrefixToPath() = %v, want %v", prefixedPath, tt.expectedPath)
+			}
+
+			// Test parseRequestPath với path đã được prefix
+			bucket, path := parseRequestPath(prefixedPath)
+			t.Logf("Bucket: %s, Path: %s", bucket, path)
+
+			// Verify kết quả phù hợp với kỳ vọng
+			if tt.prefix != "" && bucket == "" {
+				t.Error("Expected non-empty bucket when prefix is set")
+			}
+		})
+	}
+}
+
+// Unit tests cho các hàm helper mới
+
+func TestParseRequestPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		urlPath    string
+		wantBucket string
+		wantPath   string
+	}{
+		{
+			name:       "normal path",
+			urlPath:    "/mybucket/folder/file.jpg",
+			wantBucket: "mybucket",
+			wantPath:   "folder/file.jpg",
+		},
+		{
+			name:       "root file",
+			urlPath:    "/mybucket/file.jpg",
+			wantBucket: "mybucket",
+			wantPath:   "file.jpg",
+		},
+		{
+			name:       "bucket only",
+			urlPath:    "/mybucket",
+			wantBucket: "mybucket",
+			wantPath:   "",
+		},
+		{
+			name:       "deep nested path",
+			urlPath:    "/mybucket/a/b/c/d/file.jpg",
+			wantBucket: "mybucket",
+			wantPath:   "a/b/c/d/file.jpg",
+		},
+		{
+			name:       "empty path",
+			urlPath:    "/",
+			wantBucket: "",
+			wantPath:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBucket, gotPath := parseRequestPath(tt.urlPath)
+			if gotBucket != tt.wantBucket {
+				t.Errorf("parseRequestPath() bucket = %v, want %v", gotBucket, tt.wantBucket)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("parseRequestPath() path = %v, want %v", gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestApplyPrefixToPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		input    string
+		expected string
+	}{
+		{"No prefix", "", "/img.jpg", "/img.jpg"},
+		{"Single segment", "my-bucket", "/img.jpg", "/my-bucket/img.jpg"},
+		{"Multi segment", "bucket/folder", "/img.jpg", "/bucket/folder/img.jpg"},
+		{"Edge: empty path", "bucket", "", "/bucket/"},
+		{"Edge: root path", "bucket", "/", "/bucket/"},
+		{"Edge: prefix with trailing slash", "bucket/", "/img.jpg", "/bucket/img.jpg"},
+		{"Edge: path with multiple slashes", "bucket", "//img.jpg", "/bucket//img.jpg"},
+		{"Nested prefix", "app/v1/data", "/users/profile.json", "/app/v1/data/users/profile.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set PREFIX_PATH environment variable
+			oldPrefix := os.Getenv("PREFIX_PATH")
+			defer os.Setenv("PREFIX_PATH", oldPrefix)
+			os.Setenv("PREFIX_PATH", tt.prefix)
+
+			result := applyPrefixToPath(tt.input)
+			if result != tt.expected {
+				t.Errorf("applyPrefixToPath() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     *client.S3Object
+		wantStatus int
+	}{
+		{
+			name: "normal response",
+			output: &client.S3Object{
+				StatusCode:   200,
+				ContentRange: "",
+			},
+			wantStatus: 200,
+		},
+		{
+			name: "partial content response",
+			output: &client.S3Object{
+				StatusCode:   200,
+				ContentRange: "bytes 0-1023/2048",
+			},
+			wantStatus: 206,
+		},
+		{
+			name: "custom status code",
+			output: &client.S3Object{
+				StatusCode:   304,
+				ContentRange: "",
+			},
+			wantStatus: 304,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus := getStatusCode(tt.output)
+			if gotStatus != tt.wantStatus {
+				t.Errorf("getStatusCode() = %v, want %v", gotStatus, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestSetResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *client.S3Object
+		want   map[string]string
+	}{
+		{
+			name: "complete headers",
+			output: &client.S3Object{
+				ContentType:   "image/jpeg",
+				ContentLength: 1024,
+				ETag:          "\"abc123\"",
+				ContentRange:  "bytes 0-1023/2048",
+				Metadata: map[string]string{
+					"user-id":      "12345",
+					"upload-time":  "2023-01-01",
+					"wasabi-class": "standard", // Should be filtered
+				},
+			},
+			want: map[string]string{
+				"Content-Type":           "image/jpeg",
+				"Content-Length":         "1024",
+				"ETag":                   "\"abc123\"",
+				"Content-Range":          "bytes 0-1023/2048",
+				"x-amz-meta-user-id":     "12345",
+				"x-amz-meta-upload-time": "2023-01-01",
+			},
+		},
+		{
+			name: "minimal headers",
+			output: &client.S3Object{
+				ContentType: "text/plain",
+				Metadata:    map[string]string{},
+			},
+			want: map[string]string{
+				"Content-Type": "text/plain",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			setResponseHeaders(w, tt.output)
+
+			for key, wantValue := range tt.want {
+				gotValue := w.Header().Get(key)
+				if gotValue != wantValue {
+					t.Errorf("setResponseHeaders() header %s = %v, want %v", key, gotValue, wantValue)
+				}
+			}
+
+			// Verify wasabi headers are filtered
+			for key := range w.Header() {
+				if strings.Contains(strings.ToLower(key), "wasabi") {
+					t.Errorf("setResponseHeaders() should filter wasabi header: %s", key)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
This commit introduces a new function `applyPrefixToPath` to handle the application of the `PREFIX_PATH` configuration to the request path. The changes are as follows:

1. Implement the `applyPrefixToPath` function in `api/s3.go` to apply the `PREFIX_PATH` to the original request path, if configured.
2. Update the `Handler` function to call `applyPrefixToPath` before parsing the request path, ensuring the prefix is applied before any other processing.
3. Remove the obsolete `applyPrefix` function, as its functionality is now handled by the new `applyPrefixToPath`.
4. Add comprehensive unit tests for the `applyPrefixToPath` function in `api/s3_test.go` to cover various edge cases.

The main benefits of this refactor are:

1. **Separation of Concerns**: The `applyPrefixToPath` function is responsible solely for applying the prefix, adhering to the Single Responsibility Principle.
2. **Improved Testability**: The new function can be easily tested in isolation, leading to higher test coverage and better confidence in the code.
3. **Self-Documenting Code**: The function names, `applyPrefixToPath` and `parseRequestPath`, clearly describe their respective responsibilities.
4. **Reduced Complexity**: The `Handler` function is now simpler, with a more straightforward flow of execution.

This refactor lays the foundation for further improvements to the S3 handler function, making the codebase more maintainable and extensible.